### PR TITLE
Avoid accidental early exits

### DIFF
--- a/src/app/_utils/accessLocalStorage.ts
+++ b/src/app/_utils/accessLocalStorage.ts
@@ -19,29 +19,37 @@ import { Move } from './localStorageTypes'
 export const updateLocalStorageGlobal = {
   [lsFlows]: (val: Flow[], accessToLocalStorage: boolean) => {
     //quit early if localstorage unaccessible
-    if (!accessToLocalStorage)
-      if (isFlowArr(val))
-        //validation
-        localStorage.setItem(lsFlows, JSON.stringify(val))
-      else {
-        console.log('failed validation')
-      }
+    if (!accessToLocalStorage) {
+      return;
+    }
+    
+    if (isFlowArr(val)) {
+      //validation
+      localStorage.setItem(lsFlows, JSON.stringify(val))
+    } else {
+      console.log('failed validation')
+    }
   },
   [lsUserMoves]: (val: string[], accessToLocalStorage: boolean) => {
     //quit early if localstorage unaccessible
-    if (!accessToLocalStorage)
-      if (isUserMoves(val)) {
-        //validation
-        localStorage.setItem(lsUserMoves, JSON.stringify(val))
-      } else {
-        console.log('failed validation')
-      }
+    if (!accessToLocalStorage) {
+      return;
+    }
+
+    if (isUserMoves(val)) {
+      //validation
+      localStorage.setItem(lsUserMoves, JSON.stringify(val))
+    } else {
+      console.log('failed validation')
+    }
   },
   //--------------------LEARN MOVES PAGE------------
   [lsUserLearning]: (val: Move[], accessToLocalStorage: boolean) => {
     console.log('updating')
     //quit early if localstorage unaccessible
-    if (!accessToLocalStorage) return
+    if (!accessToLocalStorage) {
+      return;
+    }
 
     console.log('validating')
     //validation


### PR DESCRIPTION
**What:** 
updateLocalStorageGlobal was accidentally exiting early. Which is causing a number of functions attempting to save to local storage to appear to fail by requiring a lack of access to local storage. 

**How:**
Adds in the missing returns.

**Testing Completed:**

- [x] Tested saving state in Your Moves
- [x] Tested saving state in Learn Moves
- [x] Tested editing the content of moves. 

**Static Analysis:**

- [x] Yarn lint
- [x] Yarn ts (Has some errors but unrelated to change set.
